### PR TITLE
fix: escape job descriptions and improve jobs board previews

### DIFF
--- a/app/jobs/templates/jobs/detail.html
+++ b/app/jobs/templates/jobs/detail.html
@@ -60,7 +60,7 @@
         <div class="card-body p-6">
           <h2 class="m-0 mb-4 text-xl font-bold text-blue">Job Description</h2>
           <div class="markdown-content">
-            {{ job.description|safe }}
+            {{ job.description|linebreaks }}
           </div>
         </div>
       </div>

--- a/app/jobs/templates/jobs/index.html
+++ b/app/jobs/templates/jobs/index.html
@@ -72,8 +72,10 @@
               {% endif %}
             </div>
 
-            {% if job.short_description %}
-              <p class="m-0 mt-3 text-sm leading-relaxed opacity-80 line-clamp-2">{{ job.short_description }}</p>
+            {% if job.short_description or job.description %}
+              <p class="m-0 mt-3 text-sm leading-relaxed opacity-80 line-clamp-2">
+                {% if job.short_description %}{{ job.short_description }}{% else %}{{ job.description|striptags|truncatechars:180 }}{% endif %}
+              </p>
             {% endif %}
 
             {% if job.tags.all %}
@@ -85,7 +87,7 @@
             {% endif %}
 
             <div class="mt-5 flex flex-wrap items-center gap-3 border-t pt-4 {% if job.is_sponsored %}border-white/20{% else %}border-base-300{% endif %}">
-              <a href="{% url 'jobs:job_detail' job.pk %}" class="btn btn-ghost btn-sm">View Details</a>
+              <a href="{% url 'jobs:job_detail' job.pk %}" class="btn btn-ghost btn-sm {% if job.is_sponsored %}text-white hover:bg-white/10{% endif %}">View Details</a>
               {% if job.application_url %}
                 <a href="{{ job.application_url }}" target="_blank" rel="noopener" class="btn btn-primary btn-sm">Apply</a>
               {% endif %}

--- a/templates/includes/navbar.html
+++ b/templates/includes/navbar.html
@@ -20,6 +20,7 @@
     <ul class="hidden items-center gap-7 lg:ml-auto lg:flex">
       <li><a href="{% url 'landing:landing' %}#about" class="nav-link text-sm font-medium text-white/85 no-underline transition-colors hover:text-yellow">About</a></li>
       <li><a href="{% url 'events:events' %}" class="nav-link text-sm font-medium text-white/85 no-underline transition-colors hover:text-yellow">Events</a></li>
+      <li><a href="{% url 'jobs:index' %}" class="nav-link text-sm font-medium text-white/85 no-underline transition-colors hover:text-yellow">Jobs</a></li>
       <li><a href="{% url 'landing:landing' %}#community" class="nav-link text-sm font-medium text-white/85 no-underline transition-colors hover:text-yellow">Community</a></li>
       <li><a href="{% url 'landing:landing' %}#resources" class="nav-link text-sm font-medium text-white/85 no-underline transition-colors hover:text-yellow">Resources</a></li>
       <li>
@@ -61,6 +62,7 @@
     <ul class="flex flex-col gap-1 px-4 py-4">
       <li><a href="{% url 'landing:landing' %}#about" class="block rounded-lg px-3 py-2.5 text-sm font-medium text-white/85 no-underline transition-colors hover:bg-white/5 hover:text-yellow">About</a></li>
       <li><a href="{% url 'events:events' %}" class="block rounded-lg px-3 py-2.5 text-sm font-medium text-white/85 no-underline transition-colors hover:bg-white/5 hover:text-yellow">Events</a></li>
+      <li><a href="{% url 'jobs:index' %}" class="block rounded-lg px-3 py-2.5 text-sm font-medium text-white/85 no-underline transition-colors hover:bg-white/5 hover:text-yellow">Jobs</a></li>
       <li><a href="{% url 'landing:landing' %}#community" class="block rounded-lg px-3 py-2.5 text-sm font-medium text-white/85 no-underline transition-colors hover:bg-white/5 hover:text-yellow">Community</a></li>
       <li><a href="{% url 'landing:landing' %}#resources" class="block rounded-lg px-3 py-2.5 text-sm font-medium text-white/85 no-underline transition-colors hover:bg-white/5 hover:text-yellow">Resources</a></li>
       <li><a href="https://pycon.python.ph/" class="block rounded-lg px-3 py-2.5 text-sm font-medium text-white/85 no-underline transition-colors hover:bg-white/5 hover:text-yellow">PyCon PH</a></li>


### PR DESCRIPTION
This pull request introduces improvements to the job listings and navigation experience. It enhances how job descriptions are displayed, ensures the Jobs page is accessible from the main navigation, and visually distinguishes sponsored jobs in the job list.

**Job listing and detail improvements:**

* On the job detail page, job descriptions now use the `linebreaks` filter, preserving paragraph formatting for better readability.
* On the job index page, if a short description is missing, a truncated and stripped version of the main description is shown instead, ensuring all jobs have a summary.
* The "View Details" button for sponsored jobs now has a distinct style, making them stand out visually.

**Navigation updates:**

* Added a "Jobs" link to both the desktop and mobile navigation menus, making the Jobs page easier to find. [[1]](diffhunk://#diff-c823b2220b2605916c070aa7d6ad56803de54872cf2805c0756ba2ec983f6fa3R23) [[2]](diffhunk://#diff-c823b2220b2605916c070aa7d6ad56803de54872cf2805c0756ba2ec983f6fa3R65)